### PR TITLE
Use char[] instead of StringBuilder for perfomance

### DIFF
--- a/src/Nanoid/Nanoid.cs
+++ b/src/Nanoid/Nanoid.cs
@@ -60,12 +60,13 @@ namespace Nanoid
             var mask = (2 << (int)Math.Floor(Math.Log(alphabet.Length - 1) / Math.Log(2))) - 1;
             var step = (int)Math.Ceiling(1.6 * mask * size / alphabet.Length);
 
-            var idBuilder = new StringBuilder();
+            var idBuilder = new char[size];
+            int cnt = 0;
 
+            var bytes = new byte[step];
             while (true)
             {
 
-                var bytes = new byte[step];
                 random.NextBytes(bytes);
 
                 for (var i = 0; i < step; i++)
@@ -74,10 +75,10 @@ namespace Nanoid
                     var alphabetIndex = bytes[i] & mask;
 
                     if (alphabetIndex >= alphabet.Length) continue;
-                    idBuilder.Append(alphabet[alphabetIndex]);
-                    if (idBuilder.Length == size)
+                    idBuilder[cnt] = alphabet[alphabetIndex];
+                    if (++cnt == size)
                     {
-                        return idBuilder.ToString();
+                        return new string(idBuilder);
                     }
 
                 }


### PR DESCRIPTION
I make some changes for perfomance improvement.
Test on Windows 10 are good:
BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.379 (1809/October2018Update/Redstone5)
Intel Core i5-7400 CPU 3.00GHz (Kaby Lake), 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=2.2.105
  [Host]        : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), 64bit RyuJIT
  Clr 64        : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3324.0
  Clr 64 Legacy : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3324.0
  Clr 86 Legacy : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3324.0
  Core 32       : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), 32bit RyuJIT
  Core X64      : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), 64bit RyuJIT


|       Method |       Jit | Platform | Runtime |     Mean |     Error |    StdDev | Gen 0/1k Op | Allocated Memory/Op |
|------------- |---------- |--------- |-------- |---------:|----------:|----------:|------------:|--------------------:|
|     Generate |    RyuJit |      X64 |     Clr | 434.7 ns | 2.1498 ns | 2.0109 ns |      0.1092 |               344 B |
| Generate_new |    RyuJit |      X64 |     Clr | 353.7 ns | 2.7366 ns | 2.2852 ns |      0.0658 |               208 B |
|     Generate | LegacyJit |      X64 |     Clr | 430.1 ns | 4.9937 ns | 4.4268 ns |      0.1092 |               344 B |
| Generate_new | LegacyJit |      X64 |     Clr | 359.6 ns | 0.6337 ns | 0.5618 ns |      0.0658 |               208 B |
|     Generate | LegacyJit |      X86 |     Clr | 757.8 ns | 4.6199 ns | 4.0954 ns |      0.0782 |               248 B |
| Generate_new | LegacyJit |      X86 |     Clr | 686.2 ns | 4.6743 ns | 4.3723 ns |      0.0505 |               160 B |
|     Generate |    RyuJit |      X86 |    Core | 630.1 ns | 5.8390 ns | 5.4618 ns |      0.0782 |               248 B |
| Generate_new |    RyuJit |      X86 |    Core | 535.2 ns | 1.6765 ns | 1.4862 ns |      0.0505 |               160 B |
|     Generate |    RyuJit |      X64 |    Core | 323.7 ns | 0.4004 ns | 0.3550 ns |      0.1092 |               344 B |
| Generate_new |    RyuJit |      X64 |    Core | 249.4 ns | 1.1008 ns | 1.0297 ns |      0.0658 |               208 B |

Tests on Ubuntu 18.10 not so impressive, may be I doing something wrong:
BenchmarkDotNet=v0.11.4, OS=ubuntu 18.10
Intel Core i5-7400 CPU 3.00GHz (Kaby Lake), 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=2.2.105
  [Host]   : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), 64bit RyuJIT
  Core X64 : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), 64bit RyuJIT

Job=Core X64  Platform=X64  Runtime=Core  

|       Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Allocated Memory/Op |
|------------- |---------:|----------:|----------:|------------:|--------------------:|
|     Generate | 1.452 us | 0.0013 us | 0.0011 us |      0.1087 |               344 B |
| Generate_new | 1.400 us | 0.0022 us | 0.0020 us |      0.0648 |               208 B |
