### PR TITLE
Add support for .NET Standard 2.1 + few improvements here and there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ solution: nanoid-net.sln
 matrix:
   include:
     - os: osx
-      osx_image: xcode9.2
-      dotnet: 2.1.2
+      osx_image: xcode11
+      dotnet: 3.1.101
       mono: none
     - os: linux
-      dist: trusty
+      dist: bionic
       sudo: required
-      dotnet: 2.1.2
+      dotnet: 3.1.100
       mono: none
 
 branches:
@@ -25,4 +25,4 @@ before_script:
 script:
   - dotnet build "src\Nanoid"
   - dotnet build "test\Nanoid.Test" -c Release
-  - dotnet test "test\Nanoid.Test\Nanoid.Test.csproj" --configuration Release --no-build
+  - dotnet test "test\Nanoid.Test\Nanoid.Test.csproj" --configuration Release --no-build --framework netcoreapp3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 nuget:
   disable_publish_on_pr: true
 build_script:

--- a/src/Nanoid/CryptoRandom.cs
+++ b/src/Nanoid/CryptoRandom.cs
@@ -8,7 +8,9 @@ namespace Nanoid
     public class CryptoRandom : Random
     {
         private static RandomNumberGenerator _r;
+#if !NETSTANDARD2_1
         private readonly byte[] _uint32Buffer = new byte[4];
+#endif
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -27,14 +29,29 @@ namespace Nanoid
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             _r.GetBytes(buffer);
         }
+
+#if NETSTANDARD2_1
+        /// <inheritdoc/>
+        public override void NextBytes(Span<byte> buffer)
+        {
+            RandomNumberGenerator.Fill(buffer);
+        }
+#endif
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
         /// <returns></returns>
         public override double NextDouble()
         {
+#if NETSTANDARD2_1
+            Span<byte> uint32Buffer = stackalloc byte[4];
+            RandomNumberGenerator.Fill(uint32Buffer);
+            return BitConverter.ToUInt32(uint32Buffer) / (1.0 + UInt32.MaxValue);
+#else
             _r.GetBytes(_uint32Buffer);
             return BitConverter.ToUInt32(_uint32Buffer, 0) / (1.0 + UInt32.MaxValue);
+#endif
         }
         /// <inheritdoc />
         /// <summary>

--- a/src/Nanoid/Nanoid.cs
+++ b/src/Nanoid/Nanoid.cs
@@ -2,6 +2,9 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+
+[assembly:InternalsVisibleTo("Nanoid.Test")]
+
 namespace Nanoid
 {
     /// <summary>
@@ -48,7 +51,7 @@ namespace Nanoid
                 throw new ArgumentNullException("alphabet cannot be null.");
             }
 
-            if (alphabet.Length == 0 || alphabet.Length >= 256)
+            if (alphabet.Length <= 0 || alphabet.Length >= 256)
             {
                 throw new ArgumentOutOfRangeException("alphabet must contain between 1 and 255 symbols.");
             }
@@ -58,7 +61,7 @@ namespace Nanoid
                 throw new ArgumentOutOfRangeException("size must be greater than zero.");
             }
 
-            var mask = (2 << (int)Math.Floor(Math.Log(alphabet.Length - 1) / Math.Log(2))) - 1;
+            var mask = (2 << 31 - Clz32((alphabet.Length - 1) | 1)) - 1;
             var step = (int)Math.Ceiling(1.6 * mask * size / alphabet.Length);
 
 #if NETSTANDARD2_1
@@ -92,6 +95,32 @@ namespace Nanoid
 
             }
 
+        }
+
+        /// <summary>
+        /// Counts leading zeros of <paramref name="x"/>.
+        /// </summary>
+        /// <param name="x">Input number.</param>
+        /// <returns>Number of leading zeros.</returns>
+        /// <remarks>
+        /// Courtesy of spender/Sunsetquest see https://stackoverflow.com/a/10439333/623392.
+        /// </remarks>
+        internal static int Clz32(int x)
+        {
+            const int numIntBits = sizeof(int) * 8; //compile time constant
+            //do the smearing
+            x |= x >> 1;
+            x |= x >> 2;
+            x |= x >> 4;
+            x |= x >> 8;
+            x |= x >> 16;
+            //count the ones
+            x -= x >> 1 & 0x55555555;
+            x = (x >> 2 & 0x33333333) + (x & 0x33333333);
+            x = (x >> 4) + x & 0x0f0f0f0f;
+            x += x >> 8;
+            x += x >> 16;
+            return numIntBits - (x & 0x0000003f); //subtract # of 1s from 32
         }
     }
 }

--- a/src/Nanoid/Nanoid.cs
+++ b/src/Nanoid/Nanoid.cs
@@ -61,6 +61,9 @@ namespace Nanoid
                 throw new ArgumentOutOfRangeException("size must be greater than zero.");
             }
 
+            // See https://github.com/ai/nanoid/blob/master/format.js for
+            // explanation why masking is use (`random % alphabet` is a common
+            // mistake security-wise).
             var mask = (2 << 31 - Clz32((alphabet.Length - 1) | 1)) - 1;
             var step = (int)Math.Ceiling(1.6 * mask * size / alphabet.Length);
 

--- a/src/Nanoid/Nanoid.cs
+++ b/src/Nanoid/Nanoid.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 namespace Nanoid
@@ -60,10 +61,16 @@ namespace Nanoid
             var mask = (2 << (int)Math.Floor(Math.Log(alphabet.Length - 1) / Math.Log(2))) - 1;
             var step = (int)Math.Ceiling(1.6 * mask * size / alphabet.Length);
 
+#if NETSTANDARD2_1
+            Span<char> idBuilder = stackalloc char[size];
+            Span<byte> bytes = stackalloc byte[step];
+#else
             var idBuilder = new char[size];
+            var bytes = new byte[step];
+#endif
+
             int cnt = 0;
 
-            var bytes = new byte[step];
             while (true)
             {
 

--- a/src/Nanoid/Nanoid.csproj
+++ b/src/Nanoid/Nanoid.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFramework>netstandard2.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <Version>2.0.0</Version>

--- a/test/Nanoid.Test/Nanoid.Test.csproj
+++ b/test/Nanoid.Test/Nanoid.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Nanoid.Test/NanoidTest.cs
+++ b/test/Nanoid.Test/NanoidTest.cs
@@ -47,6 +47,26 @@ namespace Nanoid.Test
         }
 
         [Fact]
+        public void TestSingleLetterAlphabet()
+        {
+            var actual = Nanoid.Generate("a", 5);
+
+            Assert.Equal("aaaaa", actual);
+        }
+
+        [Theory]
+        [InlineData(4, "adca")]
+        [InlineData(18, "cbadcbadcbadcbadcc")]
+        public void TestPredefinedRandomSequence(int size, string expected)
+        {
+            byte[] sequence = { 2, 255, 3, 7, 7, 7, 7, 7, 0, 1 };
+            var random = new PredefinedRandomSequence(sequence);
+            var actual = Nanoid.Generate(random, "abcde", size);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public async Task TestAsyncGenerate()
         {
         

--- a/test/Nanoid.Test/NanoidTest.cs
+++ b/test/Nanoid.Test/NanoidTest.cs
@@ -111,6 +111,17 @@ namespace Nanoid.Test
             }
         }
 
+        [Fact]
+        public void TestMask()
+        {
+            for (var length = 1; length < 256; length++)
+            {
+                var mask1 = (2 << (int)Math.Floor(Math.Log(length - 1) / Math.Log(2))) - 1;
+                var mask2 = (2 << 31 - Nanoid.Clz32((length - 1) | 1)) - 1;
+                Assert.Equal(mask1, mask2);
+            }
+        }
+
         private static bool ToBeCloseTo(double actual, double expected, int precision = 2)
         {
             var pass = Math.Abs(expected-actual) < Math.Pow(10, -precision)/2;

--- a/test/Nanoid.Test/PredefinedRandomSequence.cs
+++ b/test/Nanoid.Test/PredefinedRandomSequence.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nanoid.Test
+{
+    public class PredefinedRandomSequence : Random
+    {
+        private readonly byte[] _sequence;
+
+        public PredefinedRandomSequence(byte[] sequence)
+        {
+            _sequence = sequence;
+        }
+
+        public override void NextBytes(byte[] buffer)
+        {
+            var seq = GetSequence(buffer.Length).GetEnumerator();
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                seq.MoveNext();
+                buffer[i] = seq.Current;
+            }
+        }
+
+#if NETCOREAPP3_0
+        public override void NextBytes(Span<byte> buffer)
+        {
+            var bytes = new byte[buffer.Length];
+            NextBytes(bytes);
+            bytes.CopyTo(buffer);
+        }
+#endif
+
+        private IEnumerable<byte> GetSequence(int size)
+        {
+            var result = _sequence.AsEnumerable();
+            // Update the sequence to match nanoid.js tests and implementation
+            // which takes random bytes in reverse order (as of 3489e1e3b0dd7678b72c30f5fb00b806c8ce4fef).
+            for (var i = 0; i < (size / _sequence.Length); i++)
+            {
+                result = result.Concat(result);
+            }
+
+            return result.Take(size).Reverse();
+        }
+    }
+}


### PR DESCRIPTION
* Add `netstandard2.1` target
  * Test is also multi-targeted to test both .NET Standard 2.0/2.1 implementations (Unix/Travis will only run `netcoreapp3.0` target, Windows will run both)
* Use `stackalloc` if possible to reduce allocations
* Remove floating point operations from mask computation
* Add few tests
* Updated CI images