### PR TITLE
Change namespace to NanoidDotNet

### DIFF
--- a/src/Nanoid/CryptoRandom.cs
+++ b/src/Nanoid/CryptoRandom.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Security.Cryptography;
-namespace Nanoid
+namespace NanoidDotNet
 {
     /// <inheritdoc />
     /// <summary>

--- a/src/Nanoid/Nanoid.cs
+++ b/src/Nanoid/Nanoid.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 [assembly:InternalsVisibleTo("Nanoid.Test")]
 
-namespace Nanoid
+namespace NanoidDotNet
 {
     /// <summary>
     /// 

--- a/src/Nanoid/Nanoid.csproj
+++ b/src/Nanoid/Nanoid.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>3.0.0</Version>
     <authors>codeyu</authors>
     <AssemblyName>Nanoid</AssemblyName>
     <PackageId>Nanoid</PackageId>

--- a/src/Nanoid/Nanoid.csproj
+++ b/src/Nanoid/Nanoid.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <authors>codeyu</authors>
     <AssemblyName>Nanoid</AssemblyName>
     <PackageId>Nanoid</PackageId>

--- a/test/Nanoid.Test/NanoidTest.cs
+++ b/test/Nanoid.Test/NanoidTest.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
-using Nanoid;
 using System.Linq;
 
-namespace Nanoid.Test
+namespace NanoidDotNet.Test
 {
     public class NanoidTest
     {

--- a/test/Nanoid.Test/PredefinedRandomSequence.cs
+++ b/test/Nanoid.Test/PredefinedRandomSequence.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Nanoid.Test
+namespace NanoidDotNet.Test
 {
     public class PredefinedRandomSequence : Random
     {


### PR DESCRIPTION
As stated in issue #8 currently it is impossible to just use `Nanoid.Generate` method since class name and namespace name are the same. `NanoidDotNet` seems like an appropriate name