### PR TITLE
Target .NET Framework 4.8 and .NET 8. Update Nuget packages

### DIFF
--- a/src/Nanoid/Nanoid.csproj
+++ b/src/Nanoid/Nanoid.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net48</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <Version>3.0.0</Version>

--- a/test/Nanoid.Test/Nanoid.Test.csproj
+++ b/test/Nanoid.Test/Nanoid.Test.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net7</TargetFrameworks>
+    <TargetFrameworks>net48;net8</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <CheckEolTargetFramework>true</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed the AppVeyor builds were failing, probably due to .NET Core 2.x SDKs no longer being available in the build images they use.

Targeting .NET Standard 2.0 and .NET 8 should cover most .NET versions that are not EOL, shouldn't it?

I didn't change the version as I'm not sure how you'd normally handle this in this project 😅