### PR TITLE
Uses Int32.LeadingZeroCount on .NET 7.0 or greater

### DIFF
--- a/src/Nanoid/Nanoid.cs
+++ b/src/Nanoid/Nanoid.cs
@@ -251,7 +251,7 @@ namespace NanoidDotNet
             // mistake security-wise.
 
             // Use `Int32.LeadingZeroCount` on .net7 and above
-            #if NET7_0
+            #if NET7_0_OR_GREATER
             var mask = (2 << 31 - Int32.LeadingZeroCount(alphabet.Length - 1 | 1)) - 1;
             #else
             var mask = (2 << 31 - Clz32((alphabet.Length - 1) | 1)) - 1;
@@ -298,7 +298,7 @@ namespace NanoidDotNet
         }
 
         // On dotnet7 and above we use `Int32.LeadingZeroCount` instead of this.
-        #if !NET7_0
+        #if !NET7_0_OR_GREATER
         /// <summary>
         /// Counts leading zeros of <paramref name="x"/>.
         /// </summary>

--- a/test/Nanoid.Test/NanoidTest.cs
+++ b/test/Nanoid.Test/NanoidTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using System.Linq;
 
 namespace NanoidDotNet.Test
 {
@@ -136,7 +136,7 @@ namespace NanoidDotNet.Test
             for (var length = 1; length < 256; length++)
             {
                 var mask1 = (2 << (int)Math.Floor(Math.Log(length - 1) / Math.Log(2))) - 1;
-                #if NET7_0
+                #if NET7_0_OR_GREATER
                 var mask2 = (2 << 31 - Int32.LeadingZeroCount((length - 1) | 1)) - 1;
                 #else
                 var mask2 = (2 << 31 - Nanoid.Clz32((length - 1) | 1)) - 1;


### PR DESCRIPTION
Fixes #22 (replaces NET7_0 by NET7_0_OR_GREATER)