### PR TITLE
fix NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nanoid-net
 [![Build Status](https://travis-ci.org/codeyu/nanoid-net.svg?branch=master)](https://travis-ci.org/codeyu/nanoid-net) [![Build status](https://ci.appveyor.com/api/projects/status/i1ni7r193fs4t9tq/branch/master?svg=true)](https://ci.appveyor.com/project/codeyu/nanoid-net/branch/master)
-[![NuGet Badge](https://buildstats.info/nuget/Nanoid)](https://www.nuget.org/packages/Nanoid/) 
+[![NuGet Badge](https://img.shields.io/nuget/v/Nanoid)](https://www.nuget.org/packages/Nanoid/) 
 [![License](https://img.shields.io/badge/license-MIT%20License-blue.svg)](LICENSE)
 
 This package is .NET implementation of [ai's](https://github.com/ai) [nanoid](https://github.com/ai/nanoid)!


### PR DESCRIPTION
The website https://buildstats.info/ is no longer accessible, and its source code repository https://github.com/dustinmoris/CI-BuildStats was archived on August 31, 2024. As a result, the NuGet badge should be updated.

Preview: https://github.com/myd7349/nanoid-net/tree/fix-nuget-badge